### PR TITLE
Support ligh/dark logo on the banner

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,10 @@
 <p align="center">
-  <a href="https://nimblehq.co/"><img src="https://assets.nimblehq.co/logo/dark/logo-dark-text-320.png" /></a>
+  <a href="https://nimblehq.co/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-320.png">
+      <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png">
+    </picture>    
+  </a>
   <h2 align="center">We build outstanding software with expertise and passion</h2>
 </p>
 


### PR DESCRIPTION
## What happened

Update the template to support both the Light/Dark logos.

## Insights

Inspired by https://www.stefanjudis.com/notes/how-to-define-dark-light-mode-images-in-github-markdown/

## Proof of Work

https://user-images.githubusercontent.com/13435717/173320267-f806c5fc-9035-4871-b459-99423c347116.mov